### PR TITLE
Adds client-side table of contents

### DIFF
--- a/templates/hierarchical/behavior.js
+++ b/templates/hierarchical/behavior.js
@@ -10,6 +10,7 @@ for (const section of sections) {
 document.body.addEventListener('click', evt => {
   if (evt.target && evt.target.matches('.toggleable')) {
     evt.target.classList.toggle('toggle-collapsed');
+    evt.stopPropagation();
   }
 });
 
@@ -43,3 +44,74 @@ const lastBuilt = document.querySelector('.last-built');
 if (lastBuilt) {
   lastBuilt.textContent = now;
 }
+
+function* getHeading(node) {
+  const children = node.querySelector('h1, h2, h3, h4, h5, h6, .pseudo-heading')
+    .childNodes;
+
+  // Nodes are by reference, not value
+  // So, you need to clone first
+  for (const child of children) yield child.cloneNode();
+}
+
+function getTOC(root = document.body) {
+  function traverse(node, accumulator) {
+    if (!node) return accumulator;
+    while (node) {
+      accumulator.push({
+        // Iterable of Node instances, so you can use HTML in your headings
+        heading: getHeading(node),
+        href: node.id ? `#${node.id}` : undefined,
+        children: traverse(walker.firstChild(), []),
+      });
+      // The currrentNode is updated on recursive traversal.
+      // Need to reset to traverse siblings.
+      walker.currentNode = node;
+      node = walker.nextSibling();
+    }
+    return accumulator;
+  }
+  const walker = document.createTreeWalker(
+    root,
+    NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode: node => {
+        if ('SECTION' === node.nodeName) {
+          return NodeFilter.FILTER_ACCEPT;
+        }
+        return NodeFilter.FILTER_REJECT;
+      },
+    },
+    false
+  );
+
+  return traverse(walker.nextNode(), [], walker);
+}
+
+function renderTOC(toc, levels = [0]) {
+  const ul = document.createElement('ul');
+  for (const item of toc) {
+    const a = document.createElement('a');
+    a.setAttribute('href', item.href);
+    // Increment the leaf level
+    levels[levels.length - 1]++;
+    const level = `${levels.join('.')}. `;
+    const span = document.createElement('span');
+    span.appendChild(document.createTextNode(level));
+    a.appendChild(span);
+    // item.heading is a NodeList, not a string
+    for (const titleChild of item.heading) {
+      a.appendChild(titleChild);
+    }
+    const li = document.createElement('li');
+    li.appendChild(a);
+    if (item.children && item.children.length > 0) {
+      li.classList.add('toggleable');
+      li.appendChild(renderTOC(item.children, [...levels, 0]));
+    }
+    ul.appendChild(li);
+  }
+  return ul;
+}
+
+document.querySelector('#TOC').appendChild(renderTOC(getTOC()));

--- a/templates/hierarchical/hierarchical.css
+++ b/templates/hierarchical/hierarchical.css
@@ -30,14 +30,6 @@ h6 a[href^='#'] {
   font-weight: normal;
   text-decoration: none;
 }
-h1 a[href^='#']:hover,
-h2 a[href^='#']:hover,
-h3 a[href^='#']:hover,
-h4 a[href^='#']:hover,
-h5 a[href^='#']:hover,
-h6 a[href^='#']:hover {
-  color: #333;
-}
 
 a code {
   color: inherit;
@@ -354,10 +346,7 @@ body > section {
 .toggleable {
   position: relative;
 
-  cursor: nw-resize;
-}
-.toggleable.toggle-collapsed {
-  cursor: se-resize;
+  cursor: default;
 }
 
 .toggleable:before {
@@ -395,11 +384,6 @@ section.level2.toggleable:before {
 .meta .psuedo-heading {
   font-style: italic;
 }
-.meta.toggleable:before {
-  top: -0.75rem;
-
-  color: #ccc;
-}
 
 .meta dt {
   margin-top: 0.5em;
@@ -415,6 +399,58 @@ section.level2.toggleable:before {
 }
 .meta tbody td:first-child {
   white-space: nowrap;
+}
+
+nav#TOC ul {
+  padding-left: 0.75em;
+
+  list-style: none;
+}
+
+nav#TOC ul {
+  padding-left: 0;
+
+  /* outline: solid 1px orange; */
+}
+nav#TOC ul ul {
+  padding-left: 0.75em;
+}
+nav#TOC li {
+  margin: 0;
+
+  /* outline: solid 1px red; */
+}
+
+/* <https://specificity.keegan.st> */
+#TOC li.toggleable.toggle-collapsed > a {
+  display: block;
+}
+.meta.toggleable:before,
+#TOC li.toggleable:before {
+  top: 0;
+  left: -1rem;
+
+  color: #ccc;
+  font-size: 0.9rem;
+}
+
+@media only screen and (min-width : 12000px) {
+  nav#TOC {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+
+    overflow: scroll;
+
+    width: 20rem;
+    padding: 0.5rem;
+
+    border-left: solid 1px #ccc;
+    box-shadow: -2px 2px 10px 0 rgba(0, 0, 0, 0.20);
+
+    font-size: 0.9rem;
+  }
 }
 
 

--- a/templates/hierarchical/template.html
+++ b/templates/hierarchical/template.html
@@ -2,7 +2,6 @@
 <html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
 <head>
   <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 $for(author-meta)$
   <meta name="author" content="$author-meta$">
@@ -37,20 +36,11 @@ $endfor$
 $if(title)$
 <header>
 <h1 class="title">$title$</h1>
-$if(subtitle)$
-<p class="subtitle">$subtitle$</p>
-$endif$
-$for(author)$
-<p class="author">$author$</p>
-$endfor$
-$if(date)$
-<p class="date">$date$</p>
-$endif$
 </header>
 $endif$
 $if(toc)$
 <nav id="$idprefix$TOC">
-$toc$
+<!-- $toc$ -->
 </nav>
 $endif$
 $body$


### PR DESCRIPTION
The default Pandoc ToC wasn’t quite usable. The numbering assumes the top-level headings start at h1, not h2. (The h1 is supposed to come from the document `title` metadata.)

    pandoc \
      --from=markdown_strict+header_attributes+yaml_metadata_block\
      --to=html5 \
      --self-contained \
      --template="hierarchical/template.html" \
      --section-divs \
      --output="$1.html" \
      --toc \
      --toc-depth=6 \
      "$1.md"

Fixes #4